### PR TITLE
Use env variables, better english docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,35 @@
 # mail2rss
 
-English version goes [here](README_EN.md).
-___
+## English documentation [here](README_EN.md).
+
+---
+
 0 成本的邮件转 RSS 做法。
 使用 [cloudflare workers](https://workers.cloudflare.com/) 和 [testmail.app](https://testmail.app/)。
 
 cloudflare workers 每天免费请求量 100,000 次。  
 testmail.app 免费版每个月可以接收 100 封邮件，邮件可以保存一天。
 
-也就是说，只要你的RSS阅读器请求频率小于一天，你都能毫无遗漏的接收每一封邮件。
+也就是说，只要你的 RSS 阅读器请求频率小于一天，你都能毫无遗漏的接收每一封邮件。
 
 ## 如何使用
 
 将 [mailrss.js](mail2rss.js) 的内容复制到 cloudflare workers 的代码中，填好前面几行的内容，部署即可。
+[Check how to define environment variables in cloudflare workers](https://developers.cloudflare.com/workers/platform/environment-variables/#environment-variables-via-the-dashboard)
 
 ```js
-const allowAnyTag = true; // 允许任意的 tag
-const allowedTags = ["quartz"]; // 允许请求的 tag(需要关掉上一条这个才生效)
-const testmailNamespace = "xxxxx"; // testmail 的 namespace
-const testmailToken = "xxxxxxxxxxxxxxx"; // testmail 的 api key
-const deployUrl = "https://xxx.xxx.workers.dev/"; // 要部署到的 workers 的域名
+ALLOW_ANY_TAG = true; // 允许任意的 tag
+ALLOWED_TAGS = ["quartz"]; // 允许请求的 tag(需要关掉上一条这个才生效)
+TESTMAIL_NAMESPACE = "xxxxx"; // testmail 的 namespace
+TESTMAIL_API_KEY = "xxxxxxxxxxxxxxx"; // testmail 的 api key
+DEPLOY_URL = "https://xxx.xxx.workers.dev/"; // 要部署到的 workers 的域名
 ```
 
 deploy 到 workers 之后，你可以用 `{namespace}.{tag}@inbox.testmail.app` 去订阅邮件，然后订阅 `https://xxx.xxx.workers.dev/{tag}` 就可以啦。
 
 假如我的 namespace 是 diyyy，那我就可以用 `diyyy.quartz@inbox.testmail.app` 这个邮箱来订阅 Quartz，然后订阅 `https://xxx.xxx.workers.dev/quartz` 即可。
 
-如果你希望设置一个 tag 白名单，那就设置 `allowAnyTag` 为 `false`，将需要的 tag 添加到第二行 `allowedTags` 里。  
+如果你希望设置一个 tag 白名单，那就设置 `ALLOW_ANY_TAG` 为 `false`，将需要的 tag 添加到第二行 `ALLOWED_TAGS` 里。
 
 ## 注册 testmail.app
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,50 +1,44 @@
 # mail2rss
 
-___
-zero cost practice for converting newsletter to RSS.
-using [cloudflare workers](https://workers.cloudflare.com/) and [testmail.app](https://testmail.app/)。
+---
 
-cloudflare workers has 100,000 free requests per day。  
-testmail.app's free version can receive 100 emails per month, and the mail can be saved for one day。
+zero cost method for converting newsletter to RSS.
+using [cloudflare workers](https://workers.cloudflare.com/) and [testmail.app](https://testmail.app/).
 
-that's to say, if your rss reader fetch frequency less than one day, then you can recieve every mail exactly.
+cloudflare workers allows for 100,000 free requests per day.  
+testmail.app's free tier enables you to receive 100 emails per month, and the email are saved for one day.
+If you are a student then you can apply for GitHub Student Developer Pack and for free get the testmail essential tier which allows you to recieve 10000 emails per month instead.
 
-## How to start
+## Setting up testmail.app
 
-copy the content of [mailrss.js](mail2rss.js) into cloudflare workers，and just fill in the first few lines。
+After you register, you will get your own namespace, through which different email addresses can be constructed.
 
-```js
-const allowAnyTag = true; // allow any tag
-const allowedTags = ["quartz"]; // allowed tags(Mutually exclusive with the previous line)
-const testmailNamespace = "xxxxx"; // testmail's namespace
-const testmailToken = "xxxxxxxxxxxxxxx"; // testmail's api key
-const deployUrl = "https://xxx.xxx.workers.dev/"; // deployed workers domain
-```
+Suppose my namespace is `diyyy`，we can construct such an email address like `diyyy.{tag}@inbox.testmail.app`，`{tag}` can be replaced by anything.
 
-after deployed to workers，you can use `{namespace}.{tag}@inbox.testmail.app` to subscribe newsletter，and subscibe this link `https://xxx.xxx.workers.dev/{tag}` at your rss reader。
-
-Suppose my namespace is diyyy，then I can use `diyyy.quartz@inbox.testmail.app` to subscribe _Quartz_'s newsletter，then subscibe this link `https://xxx.xxx.workers.dev/quartz`。
-
-if you want use allowedlist mode, you need to set `allowAnyTag` to `false`，and add the allowed tags to the first line(`allowedTags`)  
-
-## sign up testmail.app
-
-testmail can help us receive email, free version can receive 100 mail per month, the content of the mail can be saved for one day
-
-After everyone registers, they will get their own namespace, through which different email addresses can be constructed.
-
-Suppose my namespace is `diyyy`，we can construct such an email address like `diyyy.{tag}@inbox.testmail.app`，`{tag}` can replace by anything。
-
-for example，we can use `diyyy.quartz@inbox.testmail.app` to subscribe _Quartz_'s newsletter，or use `diyyy.stefanjudis@inbox.testmail.app` to subscribe _Stefan's web dev journey_。
+for example，we can use `diyyy.quartz@inbox.testmail.app` to subscribe to _Quartz_'s newsletter，or use `diyyy.stefanjudis@inbox.testmail.app` to subscribe to _Stefan's web dev journey_.
 
 testmail provides a rich API for getting emails, including filtering tags, matching tag prefixes, limiting counts, and support for GraphQL queries.
 
-The official document is here: <https://testmail.app/docs/>
+The official documentation is here: <https://testmail.app/docs/>
 
-After signing in，you can get your `namespace` and `api keys` at <https://testmail.app/console>, both are we will use later.
+After signing in，you can get your `namespace` and `api keys` at <https://testmail.app/console>, we will use both later.
 
-## deploy to Cloudflare Workers
+## Deploying to Cloudflare Workers
 
-first you should have a cloudflare account。and copy the content of [mailrss.js](mail2rss.js) into cloudflare workers' editor，edit the corresponding information。
+When you already have your testmail credentials copy the content of [mailrss.js](mail2rss.js) into a new cloudflare worker and define the environment variables in settings. [Check how to define environment variables in cloudflare workers](https://developers.cloudflare.com/workers/platform/environment-variables/#environment-variables-via-the-dashboard)
 
-No detailed tutorial, just copy the code and paste.
+```js
+ALLOW_ANY_TAG = true; // allow query for any tag
+ALLOWED_TAGS = ["quartz"]; // allowed tags (Mutually exclusive with the previous line - optional to define)
+TESTMAIL_NAMESPACE = "xxxxx"; // testmail's namespace
+TESTMAIL_API_KEY = "xxxxxxxxxxxxxxx"; // testmail's api key - it's recommended to use encryption for this field
+DEPLOY_URL = "https://xxx.xxx.workers.dev/"; // deployed workers domain
+```
+
+After you deploy to workers，you can use `{namespace}.{tag}@inbox.testmail.app` to subscribe to a newsletter，and subscibe to `https://xxx.xxx.workers.dev/{tag}` in your rss reader.
+
+Subscribing to `https://xxx.xxx.workers.dev/` will result in an empty feed as no tag is defined.
+
+Suppose my namespace is diyyy，then I can use `diyyy.quartz@inbox.testmail.app` to subscribe _Quartz_'s newsletter，then subscibe to `https://xxx.xxx.workers.dev/quartz`.
+
+if you want use allowedlist mode, you need to set `ALLOW_ANY_TAG` to `false`，and add the allowed tags to the (`ALLOWED_TAGS`) environment variable

--- a/mail2rss.js
+++ b/mail2rss.js
@@ -1,8 +1,10 @@
-const allowAnyTag = true;
-const allowedTags = ["quartz"];
-const testmailNamespace = "xxxxx";
-const testmailToken = "xxxxxxxxxxxxxxx";
-const deployUrl = "https://xxx.xxx.workers.dev/";
+const allowAnyTag = ALLOW_ANY_TAG;
+if (!allowAnyTag) {
+  const allowedTags = ALLOWED_TAGS;
+}
+const testmailNamespace = TESTMAIL_NAMESPACE;
+const testmailToken = TESTMAIL_API_KEY;
+const deployUrl = DEPLOY_URL;
 
 class TestMail {
   static testmailApi = "https://api.testmail.app/api/graphql";
@@ -18,6 +20,7 @@ class TestMail {
           id
           subject
           html
+          text
           from
           timestamp
           downloadUrl
@@ -109,7 +112,9 @@ async function makeRss(emails, tag) {
     }
     return `<item>
     <title><![CDATA[${value.subject}]]></title>
-    <description><![CDATA[${value.html}]]></description>
+    <description><![CDATA[${
+      value.html ? value.html : value.text
+    }]]></description>
     <pubDate>${new Date(value.timestamp).toGMTString()}</pubDate>
     <guid isPermaLink="false">${value.id}</guid>
     <link>${value.downloadUrl}</link>
@@ -120,12 +125,12 @@ async function makeRss(emails, tag) {
   return `<?xml version="1.0" encoding="UTF-8"?>
 <rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
     <channel>
-        <title><![CDATA[${tag}邮件订阅]]></title>
+        <title><![CDATA[${tag}]]></title>
         <link>${deployUrl + tag}</link>
         <atom:link href="${
           deployUrl + tag
         }" rel="self" type="application/rss+xml" />
-        <description><![CDATA[${tag}邮件订阅]]></description>
+        <description><![CDATA[${tag}]]></description>
         <generator>mail2rss</generator>
         <webMaster>lengthmin@gmail.com (Artin)</webMaster>
         <language>zh-cn</language>


### PR DESCRIPTION
This commit changes how the variables are defined - They are now defined in environment variables which is a better suited for them. This commit also adds an option to read text only emails and improves the english documentation